### PR TITLE
Fix format bot to handle EditorConfig violations

### DIFF
--- a/.github/workflows/auto-format-bot.yml
+++ b/.github/workflows/auto-format-bot.yml
@@ -90,6 +90,9 @@ jobs:
         run: |
           echo "Applying formatting fixes..."
           ./gradlew tidy "-Ptask.times=true" --max-workers 2
+          echo "Applying EditorConfig fixes (removing trailing whitespace)..."
+          # Remove trailing whitespace from all tracked files
+          git ls-files | xargs sed -i 's/[[:space:]]*$//'
 
       - name: Check if any files were changed
         id: git_changes
@@ -178,6 +181,7 @@ jobs:
             - ✅ Code formatting via \`./gradlew tidy\`
             - ✅ Java code formatted with google-java-format
             - ✅ Gradle/Groovy scripts formatted with spotless
+            - ✅ EditorConfig fixes (trailing whitespace removal)
             - ✅ All formatting validation checks now pass
 
             ### 📝 Details


### PR DESCRIPTION
- Add trailing whitespace removal to formatting fixes
- Update PR description to mention EditorConfig fixes
- This addresses the issue where ./gradlew tidy fixes code formatting but EditorConfig violations like trailing whitespace still cause the validation to fail

### Description

<!--
If this is your first contribution to Lucene, please make sure you have reviewed the contribution guide.
https://github.com/apache/lucene/blob/main/CONTRIBUTING.md
-->
